### PR TITLE
Add override login setting

### DIFF
--- a/src/Admin/Users/CapabilityList.php
+++ b/src/Admin/Users/CapabilityList.php
@@ -107,7 +107,7 @@ class CapabilityList extends \ST\Lms\Admin\Users\Capability {
 				esc_html__( 'Delete', 'skilltriks' )
 			),
 		);
-		return sprintf( '%1$s %2$s', $item, $this->row_actions( $action ) );
+		return 'skilltriks' === $item ? sprintf( '%s', $item ) : sprintf( '%1$s %2$s', $item, $this->row_actions( $action ) );
 	}
 
 	/**

--- a/src/Helpers/SettingOptions.php
+++ b/src/Helpers/SettingOptions.php
@@ -130,6 +130,12 @@ class SettingOptions {
 				'type'  => 'number',
 				'value' => isset( $this->options['due_soon'] ) ? absint( $this->options['due_soon'] ) : '',
 			),
+			'override_login'        => array(
+				'title' => esc_html__( 'Override Login', 'skilltriks' ),
+				'desc'  => sprintf( __( 'Allow all users to login into skilltriks platform', 'skilltriks' ) ),
+				'type'  => 'checkbox',
+				'value' => isset( $this->options['override_login'] ) ? absint( $this->options['override_login'] ) : 0,
+			),
 		);
 		add_action( 'admin_post_customize_theme', array( $this, 'customize_theme_options' ) );
 		add_action( 'admin_post_user_role', array( $this, 'stlms_new_user_role' ) );
@@ -145,7 +151,9 @@ class SettingOptions {
 		if ( isset( $_POST['stlms-setting-nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['stlms-setting-nonce'] ) ), 'stlms_setting' ) ) :
 			$setting_options = array();
 			foreach ( $this->fields as $key => $field ) :
-				if ( isset( $_POST[ $this->option_name ][ $key ] ) ) :
+				if ( 'checkbox' === $field['type'] ) :
+					$setting_options[ $key ] = isset( $_POST[ $this->option_name ][ $key ] ) ? 1 : 0;
+				elseif ( isset( $_POST[ $this->option_name ][ $key ] ) ) :
 					$setting_options[ $key ] = sanitize_text_field( wp_unslash( $_POST[ $this->option_name ][ $key ] ) );
 				endif;
 			endforeach;
@@ -287,6 +295,9 @@ class SettingOptions {
 			echo '<input id="' . esc_attr( $id ) . '" name=' . esc_html( $this->option_name ) . '[' . esc_attr( $id ) . ']" size="40" type="' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '" readonly/>';
 		} elseif ( 'number' === $type ) {
 			echo '<input id="' . esc_attr( $id ) . '" name=' . esc_html( $this->option_name ) . '[' . esc_attr( $id ) . ']" type="' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '" min="1" max="30"/>';
+		} elseif ( 'checkbox' === $type ) {
+			$checked = $value ? 'checked' : '';
+			echo '<input id="' . esc_attr( $id ) . '" name="' . esc_attr( $this->option_name ) . '[' . esc_attr( $id ) . ']" type="checkbox" value="1" ' . esc_attr( $checked ) . ' />';
 		} else {
 			echo '<input id="' . esc_attr( $id ) . '" name=' . esc_html( $this->option_name ) . '[' . esc_attr( $id ) . ']" size="40" type="' . esc_attr( $type ) . '" value="' . esc_attr( $value ) . '" />';
 		}
@@ -471,7 +482,7 @@ class SettingOptions {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			$caps         = isset( $_POST['users_can'] ) ? map_deep( $_POST['users_can'], 'sanitize_text_field' ) : array();
 			$user_role    = isset( $_POST['role'] ) ? sanitize_text_field( wp_unslash( $_POST['role'] ) ) : '';
-			$default_caps = ! empty( get_role( 'author' ) ) ? get_role( 'author' )->capabilities : array( 'read' => true );
+			$default_caps = ! empty( get_role( 'editor' ) ) ? get_role( 'editor' )->capabilities : array( 'read' => true );
 
 			if ( ! empty( $user_role ) && ! empty( $caps ) ) {
 				if ( array_key_exists( $user_role, $this->options['user_role'] ) ) {

--- a/src/Login/GoogleLogin.php
+++ b/src/Login/GoogleLogin.php
@@ -104,11 +104,12 @@ class GoogleLogin {
 			$email               = $google_account_info->email;
 			$settings            = get_option( 'stlms_settings' );
 			$user_roles          = ! empty( $settings['user_role'] ) ? $settings['user_role'] : array();
+			$override_login      = ! empty( $settings['override_login'] ) ? $settings['override_login'] : 0;
 
 			if ( is_email( $email ) ) {
 				$userinfo = get_user_by( 'email', $email );
 				if ( $userinfo ) {
-					if ( ! array_key_exists( reset( $userinfo->roles ), $user_roles ) ) {
+					if ( ! $override_login && ! array_key_exists( reset( $userinfo->roles ), $user_roles ) ) {
 						wp_safe_redirect(
 							add_query_arg(
 								array(

--- a/src/Shortcode/Login.php
+++ b/src/Shortcode/Login.php
@@ -51,10 +51,11 @@ class Login extends \ST\Lms\Shortcode\Register implements \ST\Lms\Interfaces\Log
 	 */
 	public function login_process() {
 		check_ajax_referer( \ST\Lms\STLMS_LOGIN_NONCE, '_stlms_nonce' );
-		$username   = isset( $_POST['username'] ) ? sanitize_text_field( wp_unslash( $_POST['username'] ) ) : '';
-		$password   = isset( $_POST['password'] ) ? sanitize_text_field( wp_unslash( $_POST['password'] ) ) : '';
-		$settings   = get_option( 'stlms_settings' );
-		$user_roles = ! empty( $settings['user_role'] ) ? $settings['user_role'] : array();
+		$username       = isset( $_POST['username'] ) ? sanitize_text_field( wp_unslash( $_POST['username'] ) ) : '';
+		$password       = isset( $_POST['password'] ) ? sanitize_text_field( wp_unslash( $_POST['password'] ) ) : '';
+		$settings       = get_option( 'stlms_settings' );
+		$user_roles     = ! empty( $settings['user_role'] ) ? $settings['user_role'] : array();
+		$override_login = ! empty( $settings['override_login'] ) ? $settings['override_login'] : 0;
 
 		$credential                  = array();
 		$credential['user_login']    = $username;
@@ -71,7 +72,7 @@ class Login extends \ST\Lms\Shortcode\Register implements \ST\Lms\Interfaces\Log
 			EL::add( 'User singon error: ' . $user_verify->get_error_message(), 'error', __FILE__, __LINE__ );
 			wp_send_json( $response );
 		}
-		if ( ! array_key_exists( reset( $user_verify->roles ), $user_roles ) ) {
+		if ( ! $override_login && ! array_key_exists( reset( $user_verify->roles ), $user_roles ) ) {
 			wp_logout();
 			$response = array(
 				'status'  => 0,


### PR DESCRIPTION
### Description

- Add override login option in the general settings.
- Changed the custom role to have the editor capability to ensure compatibility with default WordPress roles.